### PR TITLE
fixed to use multiplatform file separator

### DIFF
--- a/magic-modules-plugin/src/main/kotlin/io/labs/dotanuki/magicmodules/internal/util/ExtractCoordinates.kt
+++ b/magic-modules-plugin/src/main/kotlin/io/labs/dotanuki/magicmodules/internal/util/ExtractCoordinates.kt
@@ -5,6 +5,7 @@ import io.labs.dotanuki.magicmodules.internal.model.CanonicalModuleName
 import io.labs.dotanuki.magicmodules.internal.model.GradleBuildScript
 import io.labs.dotanuki.magicmodules.internal.model.GradleModuleInclude
 import io.labs.dotanuki.magicmodules.internal.model.GradleModuleType
+import java.io.File
 
 internal object ExtractCoordinates {
 
@@ -33,7 +34,7 @@ internal object ExtractCoordinates {
                 throw CantExtractGradleCoordinates
             }
 
-            val segments = splittedPath[1].split("/").drop(1).dropLast(1)
+            val segments = splittedPath[1].split(File.separator).drop(1).dropLast(1)
 
             when (segments.size) {
                 0 -> {

--- a/magic-modules-plugin/src/test/kotlin/io/labs/dotanuki/magicmodules/tests/internal/BuildScriptsProcessorTests.kt
+++ b/magic-modules-plugin/src/test/kotlin/io/labs/dotanuki/magicmodules/tests/internal/BuildScriptsProcessorTests.kt
@@ -15,19 +15,20 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable
 import org.junit.Test
+import java.io.File
 
 class BuildScriptsProcessorTests {
 
     @Test fun `should not process when missing buildSrc`() {
 
-        val projectPath = "/Dev/projects/tweetter"
+        val projectPath = "${File.separator}Dev${File.separator}projects${File.separator}tweetter"
 
         val projectStructure = GradleProjectStructure(
             "tweetter",
             setOf(
-                GradleBuildScript("$projectPath/build.gradle", ROOT_LEVEL),
-                GradleBuildScript("$projectPath/twetter-app/build.gradle", APPLICATION),
-                GradleBuildScript("$projectPath/twetter-core/build.gradle", LIBRARY)
+                GradleBuildScript("$projectPath${File.separator}build.gradle", ROOT_LEVEL),
+                GradleBuildScript("$projectPath${File.separator}twetter-app${File.separator}build.gradle", APPLICATION),
+                GradleBuildScript("$projectPath${File.separator}twetter-core${File.separator}build.gradle", LIBRARY)
             )
         )
 
@@ -38,16 +39,16 @@ class BuildScriptsProcessorTests {
 
     @Test fun `should process library modules`() {
 
-        val projectPath = "/home/projects/awesome-grocery"
+        val projectPath = "${File.separator}home${File.separator}projects${File.separator}awesome-grocery"
 
         val projectStructure = GradleProjectStructure(
             "awesome-grocery",
             setOf(
-                GradleBuildScript("$projectPath/build.gradle", ROOT_LEVEL),
-                GradleBuildScript("$projectPath/buildSrc/build.gradle.kts", BUILDSRC),
-                GradleBuildScript("$projectPath/core/build.gradle", LIBRARY),
-                GradleBuildScript("$projectPath/login/build.gradle", LIBRARY),
-                GradleBuildScript("$projectPath/app/build.gradle", APPLICATION)
+                GradleBuildScript("$projectPath${File.separator}build.gradle", ROOT_LEVEL),
+                GradleBuildScript("$projectPath${File.separator}buildSrc${File.separator}build.gradle.kts", BUILDSRC),
+                GradleBuildScript("$projectPath${File.separator}core${File.separator}build.gradle", LIBRARY),
+                GradleBuildScript("$projectPath${File.separator}login${File.separator}build.gradle", LIBRARY),
+                GradleBuildScript("$projectPath${File.separator}app${File.separator}build.gradle", APPLICATION)
             )
         )
 

--- a/magic-modules-plugin/src/test/kotlin/io/labs/dotanuki/magicmodules/tests/internal/ExtractCoordinatesTests.kt
+++ b/magic-modules-plugin/src/test/kotlin/io/labs/dotanuki/magicmodules/tests/internal/ExtractCoordinatesTests.kt
@@ -1,22 +1,23 @@
 package io.labs.dotanuki.magicmodules.tests.internal
 
+import io.labs.dotanuki.magicmodules.internal.MagicModulesError
 import io.labs.dotanuki.magicmodules.internal.model.CanonicalModuleName
 import io.labs.dotanuki.magicmodules.internal.model.GradleBuildScript
 import io.labs.dotanuki.magicmodules.internal.model.GradleModuleInclude
 import io.labs.dotanuki.magicmodules.internal.model.GradleModuleType
-import io.labs.dotanuki.magicmodules.internal.MagicModulesError
 import io.labs.dotanuki.magicmodules.internal.util.ExtractCoordinates
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable
 import org.junit.Test
+import java.io.File
 
 class ExtractCoordinatesTests {
 
     @Test fun `should throw when coordinates extraction not possible`() {
 
         val projectName = "friendsfinder"
-        val scriptFilePath = "/home/Dev/blogger/app/build.gradle"
+        val scriptFilePath = "${File.separator}home${File.separator}Dev${File.separator}blogger${File.separator}app${File.separator}build.gradle"
         val buildScript = GradleBuildScript(scriptFilePath, GradleModuleType.APPLICATION)
 
         val execution = ThrowingCallable { ExtractCoordinates.gradleInclude(projectName, buildScript) }
@@ -26,7 +27,7 @@ class ExtractCoordinatesTests {
 
     @Test fun `should extract coordinates with one level`() {
         val projectName = "awesome"
-        val scriptFilePath = "/home/AndroidStudioProjects/awesome/app/build.gradle"
+        val scriptFilePath = "${File.separator}home${File.separator}AndroidStudioProjects${File.separator}awesome${File.separator}app${File.separator}build.gradle"
         val buildScript = GradleBuildScript(scriptFilePath, GradleModuleType.APPLICATION)
 
         val extractedInclude = ExtractCoordinates.gradleInclude(projectName, buildScript)
@@ -42,7 +43,7 @@ class ExtractCoordinatesTests {
     @Test fun `should extract gradle module with two levels`() {
 
         val projectName = "twitter-clone"
-        val scriptFilePath = "/Desktop/twitter-clone/features/login/build.gradle.kts"
+        val scriptFilePath = "${File.separator}Desktop${File.separator}twitter-clone${File.separator}features${File.separator}login${File.separator}build.gradle.kts"
         val buildScript = GradleBuildScript(scriptFilePath, GradleModuleType.LIBRARY)
 
         val extractedInclude = ExtractCoordinates.gradleInclude(projectName, buildScript)
@@ -58,7 +59,7 @@ class ExtractCoordinatesTests {
     @Test fun `should extract gradle module with three levels`() {
 
         val projectName = "coronatracker"
-        val scriptFilePath = "/Desktop/coronatracker/features/login/recover/build.gradle.kts"
+        val scriptFilePath = "${File.separator}Desktop${File.separator}coronatracker${File.separator}features${File.separator}login${File.separator}recover${File.separator}build.gradle.kts"
         val buildScript = GradleBuildScript(scriptFilePath, GradleModuleType.LIBRARY)
 
         val extractedInclude = ExtractCoordinates.gradleInclude(projectName, buildScript)


### PR DESCRIPTION
Using this project with Windows SO doesn't works because path separator was fixed with UNIX style `/`.
Path separator was replaced to be multiplatform with `File.separator`.